### PR TITLE
Add missing `types` definition in package.json `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "require": "./dist/node/cjs/index.js"
       },
       "browser": "./dist/browser/esm/index.js",
-      "umd": "./dist/browser/umd/index.js"
+      "umd": "./dist/browser/umd/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
When trying to import the `@iden3/js-iden3-core` library into my TS project, I was getting the error:

```
Cannot find module '@iden3/js-iden3-core' or its corresponding type declarations.ts(2307)
```

![image](https://github.com/iden3/js-iden3-core/assets/1628876/9201cdf1-df4b-4ed7-ab95-e60e086e601a)

Adding the `types` entry in the exports fixes the issue. Currently using package patch to fix this for myself.