### PR TITLE
fix: improve types exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "Low level API to create and manipulate iden3 Claims.",
   "source": "./src/index.ts",
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "main": "dist/node/cjs/index.js",
   "module": "dist/node/esm/index.js",
   "exports": {
@@ -13,7 +13,8 @@
         "require": "./dist/node/cjs/index.js"
       },
       "browser": "./dist/browser/esm/index.js",
-      "umd": "./dist/browser/umd/index.js"
+      "umd": "./dist/browser/umd/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
This PR improves how types are exported in `package.json`.